### PR TITLE
Fix/2.2.x/ks 4356

### DIFF
--- a/eXoApplication/wiki/webapp/src/main/java/org/exoplatform/wiki/webui/control/UIRelatedPagesContainer.java
+++ b/eXoApplication/wiki/webapp/src/main/java/org/exoplatform/wiki/webui/control/UIRelatedPagesContainer.java
@@ -50,7 +50,7 @@ public class UIRelatedPagesContainer extends UIWikiExtensionContainer {
   public UIRelatedPagesContainer() throws Exception {
     super(); 
     breadcrumb = addChild(UIWikiBreadCrumb.class, null, "UIWikiBreadCrumb_PageInfo");
-    breadcrumb.setLink(false);
+    breadcrumb.setLink(true);
   }
 
   @Override


### PR DESCRIPTION
KS-4356 Related page is not loaded when user click on page link on Related page info box
