### PR TITLE
Fix/2.2.x/ks 4386

### DIFF
--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/macro/pagetree/PageTreeMacro.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/macro/pagetree/PageTreeMacro.java
@@ -17,7 +17,6 @@
 package org.exoplatform.wiki.rendering.macro.pagetree;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -91,6 +90,9 @@ public class PageTreeMacro extends AbstractMacro<PageTreeMacroParameters> {
     String documentName = parameters.getRoot();
     String startDepth = parameters.getStartDepth();
     excerpt = parameters.isExcerpt();
+    if (StringUtils.isEmpty(startDepth)) {
+      startDepth = "1";
+    }
     WikiPageParams params = markupContextManager.getMarkupContext(documentName, ResourceType.DOCUMENT);
     if (StringUtils.EMPTY.equals(documentName)) {
       WikiContext wikiContext = getWikiContext();
@@ -131,10 +133,7 @@ public class PageTreeMacro extends AbstractMacro<PageTreeMacroParameters> {
   private Block generateTree(WikiPageParams params, String startDepth) throws Exception {
     StringBuilder treeSb = new StringBuilder();
     StringBuilder initSb = new StringBuilder();
-    HashMap<String, Object> context = new HashMap<String, Object>();
-    context.put(TreeNode.DEPTH, startDepth);
-    context.put(TreeNode.SHOW_EXCERPT, excerpt);
-    TreeNode node = TreeUtils.getDescendants(params, context);      
+    TreeNode node = TreeUtils.getTreeNode(params);
     WikiContext wikiContext = getWikiContext();   
     String treeID = "PageTree"+ wikiContext.getPageTreeId();
     String treeRestURI = wikiContext.getTreeRestURI();

--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/macro/pagetree/PageTreeMacroParameters.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/macro/pagetree/PageTreeMacroParameters.java
@@ -70,7 +70,7 @@ public class PageTreeMacroParameters {
    * @param depth depth of children to set
    * @throws MacroExecutionException if parameter is not empty and not a number
    */
-  @PropertyDescription("Start depth of children. If not specified, no limit is applied")
+  @PropertyDescription("Start depth of children. If not specified, first level is applied")
   public void setStartDepth(String depth) throws MacroExecutionException {
     MacroUtils.validateNumberParam(depth);
     this.startDepth = depth;

--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/tree/utils/TreeUtils.java
@@ -47,29 +47,46 @@ import org.exoplatform.wiki.utils.Utils;
  */
 public class TreeUtils {
   
-  public static TreeNode getDescendants(WikiPageParams params, HashMap<String, Object> context) throws Exception {
+  /**
+   * Create a tree node with a given {@link WikiPageParams}
+   * 
+   * @param params is the wiki page parameters
+   * @return <code>TreeNode</code>
+   * @throws Exception
+   */
+  public static TreeNode getTreeNode(WikiPageParams params) throws Exception {
     Object wikiObject = Utils.getObjectFromParams(params);
     if (wikiObject instanceof WikiHome) {
       WikiHome wikiHome = (WikiHome) wikiObject;
       WikiHomeTreeNode wikiHomeNode = new WikiHomeTreeNode(wikiHome);
-      wikiHomeNode.pushDescendants(context);
       return wikiHomeNode;
     } else if (wikiObject instanceof Page) {
       PageImpl page = (PageImpl) wikiObject;
       PageTreeNode pageNode = new PageTreeNode(page);
-      pageNode.pushDescendants(context);
       return pageNode;
     } else if (wikiObject instanceof Wiki) {
       Wiki wiki = (Wiki) wikiObject;
       WikiTreeNode wikiNode = new WikiTreeNode(wiki);
-      wikiNode.pushDescendants(context);
       return wikiNode;
     } else if (wikiObject instanceof String) {
       SpaceTreeNode spaceNode = new SpaceTreeNode((String) wikiObject);
-      spaceNode.pushDescendants(context);
       return spaceNode;
     }
     return new TreeNode();
+  }
+  
+  /**
+   * Create a tree node contain all its descendant with a given {@link WikiPageParams} 
+   * 
+   * @param params is the wiki page parameters
+   * @param context is the page tree context
+   * @return <code>TreeNode</code>
+   * @throws Exception
+   */
+  public static TreeNode getDescendants(WikiPageParams params, HashMap<String, Object> context) throws Exception {
+    TreeNode treeNode = getTreeNode(params);
+    treeNode.pushDescendants(context);
+    return treeNode;
   }
   
   public static List<JsonNodeData> tranformToJson(TreeNode treeNode, HashMap<String, Object> context) throws Exception {

--- a/eXoApplication/wiki/service/src/test/java/org/exoplatform/wiki/rendering/impl/TestMacroRendering.java
+++ b/eXoApplication/wiki/service/src/test/java/org/exoplatform/wiki/rendering/impl/TestMacroRendering.java
@@ -184,7 +184,7 @@ public class TestMacroRendering extends AbstractRenderingTestCase {
                      .append("    <a class=\"SelectNode\" style=\"display:none\" href=\"http://localhost:8080/portal/classic/\" ></a>")
                      .append("    <div class=\"NodeGroup\">")
                      .append("      <script type=\"text/javascript\">")
-                     .append("        function initTree(){eXo.wiki.UITreeExplorer.init(\"PageTree123\",\"?path=portal/classic/rootPage&excerpt=false&depth=\",false );}")
+                     .append("        function initTree(){eXo.wiki.UITreeExplorer.init(\"PageTree123\",\"?path=portal/classic/rootPage&excerpt=false&depth=1\",false );}")
                      .append("        var isInIFrame = (window.location != window.parent.location) ? true : false;")
                      .append("        if (isInIFrame) {")
                      .append("          if (window.attachEvent) {window.attachEvent('onload', initTree);}")

--- a/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet.properties
+++ b/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet.properties
@@ -227,6 +227,7 @@ UITreeExplorer.label.Destination=Destination
 UITreeExplorer.label.portal=portal
 UITreeExplorer.label.group=group
 UITreeExplorer.label.user=user
+UITreeExplorer.label.loading=Loading...
 #############################################################################
 #							UIWikiPageInfoArea          																	
 #############################################################################

--- a/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_de.properties
+++ b/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_de.properties
@@ -212,6 +212,7 @@ UITreeExplorer.label.Destination=Destination
 UITreeExplorer.label.portal=portal
 UITreeExplorer.label.group=group
 UITreeExplorer.label.user=user
+UITreeExplorer.label.loading=Loading...
 #############################################################################
 #							UIWikiPageInfoArea          																	
 #############################################################################

--- a/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
+++ b/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_en.properties
@@ -227,6 +227,7 @@ UITreeExplorer.label.Destination=Destination
 UITreeExplorer.label.portal=portal
 UITreeExplorer.label.group=group
 UITreeExplorer.label.user=user
+UITreeExplorer.label.loading=Loading...
 #############################################################################
 #							UIWikiPageInfoArea          																	
 #############################################################################

--- a/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fr.properties
+++ b/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_fr.properties
@@ -227,6 +227,7 @@ UITreeExplorer.label.Destination=Destination
 UITreeExplorer.label.portal=portal
 UITreeExplorer.label.group=groupe
 UITreeExplorer.label.user=utilisateur
+UITreeExplorer.label.loading=Chargement...
 #############################################################################
 #							UIWikiPageInfoArea          																	
 #############################################################################

--- a/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_it.properties
+++ b/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_it.properties
@@ -202,6 +202,7 @@ UITreeExplorer.label.Destination=Destinazione
 UITreeExplorer.label.portal=portale
 UITreeExplorer.label.group=gruppo
 UITreeExplorer.label.user=utente
+UITreeExplorer.label.loading=Loading...
 #############################################################################
 #							UIWikiPageInfoArea          																	
 #############################################################################

--- a/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_nl.properties
+++ b/eXoApplication/wiki/webapp/src/main/resources/locale/portlet/wiki/WikiPortlet_nl.properties
@@ -212,6 +212,7 @@ UITreeExplorer.label.Destination=Destination
 UITreeExplorer.label.portal=portal
 UITreeExplorer.label.group=group
 UITreeExplorer.label.user=user
+UITreeExplorer.label.loading=Loading...
 #############################################################################
 #							UIWikiPageInfoArea          																	
 #############################################################################

--- a/eXoApplication/wiki/webapp/src/main/webapp/javascript/eXo/wiki/tree/UITreeExplorer.js
+++ b/eXoApplication/wiki/webapp/src/main/webapp/javascript/eXo/wiki/tree/UITreeExplorer.js
@@ -98,12 +98,23 @@ UITreeExplorer.prototype.render = function(param, element, isFullRender) {
   var http = eXo.wiki.UITreeExplorer.getHTTPObject();  
   var restURL = url + param;
 
-  http.open("GET", restURL, true);
+  http.open("GET", restURL, true); 
+  
+  var childBlock = document.createElement("div");
+  if (me.innerDoc) {
+    childBlock = me.innerDoc.createElement("div");
+    me.innerDoc = null;
+  }
+  childBlock.className = "NodeGroup";
+  childBlock.innerHTML = me.loading;
+  node.appendChild(childBlock);
+  
   http.onreadystatechange = function() {
     if (http.readyState == 4) {
-      me.renderTreeNodes(node, http.responseText);      
+      me.renderTreeNodes(childBlock, http.responseText);      
     }
   }
+  
   http.send("");
   element.className = "CollapseIcon";
 };
@@ -123,23 +134,16 @@ UITreeExplorer.prototype.getHTTPObject = function() {
   return false;
 };
 
-UITreeExplorer.prototype.renderTreeNodes = function(parentNode, responseText) {
+UITreeExplorer.prototype.renderTreeNodes = function(node, responseText) {
   var me = eXo.wiki.UITreeExplorer;
   var dataList = JSON.parse(responseText);
   var resultLength = dataList.jsonList.length;
 
-  var childBlock = document.createElement("div");
-  if (me.innerDoc) {
-    childBlock = me.innerDoc.createElement("div");
-    me.innerDoc = null;
-  }
-  childBlock.className = "NodeGroup";
   var str = "";
   for ( var i = 0; i < resultLength; i++) {
     str += me.buildNode(dataList.jsonList[i]);
   }
-  childBlock.innerHTML = str;
-  parentNode.appendChild(childBlock);
+  node.innerHTML = str;
 }
 
 UITreeExplorer.prototype.buildHierachyNode = function(data){

--- a/eXoApplication/wiki/webapp/src/main/webapp/templates/wiki/webui/UIWikiPortlet.gtmpl
+++ b/eXoApplication/wiki/webapp/src/main/webapp/templates/wiki/webui/UIWikiPortlet.gtmpl
@@ -20,6 +20,7 @@
   jsmanager.addJavascript("eXo.wiki.UIWikiAjaxRequest.init('" + uicomponent.WIKI_PORTLET_ACTION_PREFIX + "', '" + uicomponent.VIEW_PAGE_ACTION + "');");  
   jsmanager.addJavascript("eXo.wiki.UIWikiPortlet.init('"+uicomponent.id+ "', '" + changeModeLinkId + "');");
   jsmanager.addJavascript("eXo.wiki.UIWikiPortlet.keepSessionAlive(" + uicomponent.isKeepSessionAlive() + ");");
+  jsmanager.addJavascript("eXo.wiki.UITreeExplorer.loading ='" + _ctx.appRes("UITreeExplorer.label.loading") +"' ;");
 %>
 <script type="text/javascript"> 
   if(!eXo.env.rest){


### PR DESCRIPTION
- Resolve the CPU leak in PageTreeMacro
  TreeNode node = TreeUtils.getDescendants(params, context);  
  ..
  node.pushDescendants(context);
  It's unnecessary to push all descendants in order to create a tree node at this stage. Because only its path is used later:
  .append(node.getPath())
- The page tree macro should show the first level of children by default
- The loading animation of tree should be smoother by adding "loading.."
