### PR TITLE
Fix/2.2.x/ks 4111

### DIFF
--- a/eXoApplication/wiki/webapp/src/main/webapp/skin/DefaultSkin/webui/Stylesheet.css
+++ b/eXoApplication/wiki/webapp/src/main/webapp/skin/DefaultSkin/webui/Stylesheet.css
@@ -520,6 +520,10 @@ table.UIFormGrid div.Id {
 	padding: 20px 10px 10px;
 }
 
+.UIWikiPortlet .UIWikiContentDisplay .WikiContent table {
+	width: auto;
+}
+
 .UIWikiPageVersionsList {
 	padding-bottom: 30px;
 }
@@ -680,6 +684,10 @@ table.UIFormGrid div.Id {
 	border-spacing: 0;
 	border: 1px solid #dddddd;
 	border-right: none;
+	width: auto;
+}
+
+.UIWikiPagePreview .UIWikiPortlet .WikiContent table {
 	width: auto;
 }
 


### PR DESCRIPTION
Add css package for table of UIWikiPagePreview component to avoiding inconsistent when displaying table on IE7 and Firefox.
