### PR TITLE
Fix/2.2.x/ks 4431

### DIFF
--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/cache/MarkupKey.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/cache/MarkupKey.java
@@ -27,6 +27,8 @@ import org.exoplatform.wiki.service.WikiPageParams;
  * May 16, 2012  
  */
 public class MarkupKey implements Serializable {
+  
+  private WikiPageParams pageParams;
 
   private String         source;
 
@@ -39,12 +41,14 @@ public class MarkupKey implements Serializable {
   /**
    * Instance new markup key
    *
+   * @param pageParams the identity params of page
    * @param source the source markup
    * @param sourceSyntax the source syntax
    * @param targetSyntax the target syntax
    * @param supportSectionEdit the content supports section editing or not
    */
-  public MarkupKey(String source, String sourceSyntax, String targetSyntax, boolean supportSectionEdit) {
+  public MarkupKey(WikiPageParams pageParams, String source, String sourceSyntax, String targetSyntax, boolean supportSectionEdit) {
+    this.pageParams = pageParams;
     this.source = source;
     this.sourceSyntax = sourceSyntax;
     this.targetSyntax = targetSyntax;
@@ -58,6 +62,7 @@ public class MarkupKey implements Serializable {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
+    result = prime * result + ((pageParams == null) ? 0 : pageParams.hashCode());
     result = prime * result + ((source == null) ? 0 : source.hashCode());
     result = prime * result + ((sourceSyntax == null) ? 0 : sourceSyntax.hashCode());
     result = prime * result + (supportSectionEdit ? 1231 : 1237);
@@ -77,6 +82,11 @@ public class MarkupKey implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     MarkupKey other = (MarkupKey) obj;
+    if (pageParams == null) {
+      if (other.pageParams != null)
+        return false;
+    } else if (!pageParams.equals(other.pageParams))
+      return false;
     if (source == null) {
       if (other.source != null)
         return false;
@@ -95,6 +105,6 @@ public class MarkupKey implements Serializable {
     } else if (!targetSyntax.equals(other.targetSyntax))
       return false;
     return true;
-  }  
+  }
   
 }

--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/cache/impl/PageRenderingCacheServiceImpl.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/cache/impl/PageRenderingCacheServiceImpl.java
@@ -65,7 +65,7 @@ public class PageRenderingCacheServiceImpl implements PageRenderingCacheService 
       PageImpl page = (PageImpl) wikiService.getPageById(param.getType(), param.getOwner(), param.getPageId());
       boolean supportSectionEdit = page.hasPermission(PermissionType.EDITPAGE);
       String markup = page.getContent().getText();
-      MarkupKey key = new MarkupKey(markup, page.getSyntax(), targetSyntax, supportSectionEdit);
+      MarkupKey key = new MarkupKey(param, markup, page.getSyntax(), targetSyntax, supportSectionEdit);
       MarkupData cachedData = renderingCache.get(key);
       if (cachedData != null) {
         return cachedData.build();

--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/service/WikiPageParams.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/service/WikiPageParams.java
@@ -75,6 +75,24 @@ public class WikiPageParams {
     this.parameters = parameters;
   }
 
+  /* (non-Javadoc)
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((attachmentName == null) ? 0 : attachmentName.hashCode());
+    result = prime * result + ((owner == null) ? 0 : owner.hashCode());
+    result = prime * result + ((pageId == null) ? 0 : pageId.hashCode());
+    result = prime * result + ((parameters == null) ? 0 : parameters.hashCode());
+    result = prime * result + ((type == null) ? 0 : type.hashCode());
+    return result;
+  }
+
+  /* (non-Javadoc)
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
   @Override
   public boolean equals(Object obj) {
     if (this == obj)

--- a/eXoApplication/wiki/service/src/test/java/org/exoplatform/wiki/rendering/impl/TestPageRenderingCacheService.java
+++ b/eXoApplication/wiki/service/src/test/java/org/exoplatform/wiki/rendering/impl/TestPageRenderingCacheService.java
@@ -63,6 +63,17 @@ public final class TestPageRenderingCacheService extends AbstractRenderingTestCa
     renderingCacheService.getRenderedContent(new WikiPageParams(PortalConfig.PORTAL_TYPE, "classic", "WikiHome"),
                                                        Syntax.XHTML_1_0.toIdString());
     assertEquals(1, renderingCacheService.getRenderingCache().getCacheHit());
+    
+    wikiService.createPage(PortalConfig.PORTAL_TYPE, "classic","classicChild" , "WikiHome");
+    page.getContent().setText("{{children/}}");
+    PageImpl acmePage = (PageImpl) wikiService.getPageById(PortalConfig.PORTAL_TYPE, "classic", "WikiHome");
+    acmePage.getContent().setText("{{children/}}");
+    String classicHomeContent =  renderingCacheService.getRenderedContent(new WikiPageParams(PortalConfig.PORTAL_TYPE, "classic", "WikiHome"),
+                                                                          Syntax.XHTML_1_0.toIdString());
+    String acmeHomeContent =  renderingCacheService.getRenderedContent(new WikiPageParams(PortalConfig.PORTAL_TYPE, "acme", "WikiHome"),
+                                                                          Syntax.XHTML_1_0.toIdString());
+    assertTrue(!classicHomeContent.equals(acmeHomeContent));
+    
   }
   
   @Override


### PR DESCRIPTION
- Add page identity parameters to markup key to distinguish based context text markup cache(children, page tree,..)
- Add unit test for this case
