### PR TITLE
Fix/2.2.x/ks 4515

### DIFF
--- a/eXoApplication/poll/service/src/main/java/org/exoplatform/poll/service/ws/PollWebservice.java
+++ b/eXoApplication/poll/service/src/main/java/org/exoplatform/poll/service/ws/PollWebservice.java
@@ -53,6 +53,7 @@ public class PollWebservice implements ResourceContainer {
   private OrganizationService organizationService = null;
   
   public PollWebservice() {
+    getOrganizationService();
   }
   
   private static final CacheControl         cc;


### PR DESCRIPTION
KS-4515 | Warning "Failed to get all info of user" after login intranet home

Cause: organizationService is NULL 
then, invokes: organizationService.getMembershipHandler().findMembershipsByUser(username);
throw exception
