### PR TITLE
KS-4529: Escape illegal chracters before making query statement

### DIFF
--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/service/search/SearchData.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/service/search/SearchData.java
@@ -68,8 +68,8 @@ public class SearchData {
                     String content,
                     String wikiType,
                     String wikiOwner,
-                    String pageId) {
-    this.text = text;
+                    String pageId) {  
+    this.text = Utils.escapeIllegalCharacterInQuery(text);  	
     this.title = title;
     this.content = content;
     this.wikiType = wikiType;

--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/service/search/TemplateSearchData.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/service/search/TemplateSearchData.java
@@ -20,6 +20,7 @@ import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.wiki.mow.api.WikiNodeType;
+import org.exoplatform.wiki.utils.Utils;
 
 /**
  * Created by The eXo Platform SAS
@@ -68,7 +69,7 @@ public class TemplateSearchData extends SearchData {
   public String getStatement() {
     StringBuilder statement = new StringBuilder();
     try {
-      String title = getTitle();
+      String title = Utils.escapeIllegalCharacterInQuery(getTitle());
       statement.append("SELECT title, jcr:primaryType, path,"+WikiNodeType.Definition.DESCRIPTION)
                .append(" FROM ")
                .append(WikiNodeType.WIKI_PAGE)

--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/utils/Utils.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/utils/Utils.java
@@ -69,6 +69,8 @@ public class Utils {
 
   final private static String MIMETYPE_TEXTHTML = "text/html";
   
+  private static final String ILLEGAL_SEARCH_CHARACTERS= "\\!^()+{}[]:\"-";
+  
   //The path should get from NodeHierarchyCreator 
   public static String getPortalWikisPath() {    
     String path = "/exo:applications/" 
@@ -523,5 +525,17 @@ public class Utils {
     StringBuffer strBuffer = new StringBuffer(url);
     strBuffer.append("?").append(WikiContext.ACTION).append("=").append(COMPARE_REVISION).append("&").append(VER_NAME).append("=").append(verName);
     return strBuffer.toString();
+  }
+  /*
+   * Escape the illegal characters before making the query statement
+   */
+  public static String escapeIllegalCharacterInQuery(String query) {
+    String ret = query;
+    if(ret != null) {
+      for (char c : ILLEGAL_SEARCH_CHARACTERS.toCharArray()) {
+        ret = ret.replace(c + "", "\\" + c);
+      }
+    }
+    return ret;
   }
 }


### PR DESCRIPTION
Fix description: Escape illegal chracters before making query statement
Link issue: https://jira.exoplatform.org/browse/KS-4529
