### PR TITLE
KS-4701: [WIKI] Image URL broken if hostname contains the word portal

### DIFF
--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/impl/DefaultWikiModel.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/rendering/impl/DefaultWikiModel.java
@@ -122,7 +122,7 @@ public class DefaultWikiModel implements WikiModel {
       WikiContext wikiMarkupContext = markupContextManager.getMarkupContext(imageName, resourceType);
       String portalContainerName = PortalContainer.getCurrentPortalContainerName();
       String portalURL = wikiMarkupContext.getPortalURL();
-      String domainURL = portalURL.substring(0, portalURL.indexOf(portalContainerName) - 1);
+      String domainURL = portalURL.substring(0, portalURL.indexOf("/"+portalContainerName));
       WikiContext context =getWikiContext();
       renderingCacheService.addPageLink(new WikiPageParams(context.getType(), context.getOwner(), context.getPageId()),
                                         new WikiPageParams(wikiMarkupContext.getType(),


### PR DESCRIPTION
Fix description: Change to get correct domainURL in case hostname contains the word portal.
