### PR TITLE
KS-4720: ArrayIndexOutOfBoundsException when search wiki page not matchi...

### DIFF
--- a/eXoApplication/wiki/webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiAdvanceSearchForm.java
+++ b/eXoApplication/wiki/webapp/src/main/java/org/exoplatform/wiki/webui/UIWikiAdvanceSearchForm.java
@@ -163,15 +163,19 @@ public class UIWikiAdvanceSearchForm extends UIForm {
   public void gotoSearchPage(int pageIndex) throws Exception {
     pageIndex = (int) Math.min(pageIndex, getPageAvailable());
     WikiSearchData data = createSearchData();
-    data.setOffset((pageIndex - 1) * NUMBER_OF_RESULT_PER_PAGE);
-    data.setLimit(NUMBER_OF_RESULT_PER_PAGE);
-    
     WikiService wikiservice = (WikiService) PortalContainer.getComponent(WikiService.class);
     UIWikiAdvanceSearchResult uiSearchResults = getParent().findFirstComponentOfType(UIWikiAdvanceSearchResult.class);
     uiSearchResults.setResults(wikiservice.search(data));
-    
     UIAdvancePageIterator uiAdvancePageIterator = getParent().findFirstComponentOfType(UIAdvancePageIterator.class);
-    uiAdvancePageIterator.setCurrentPage(pageIndex);
+    
+    if(pageIndex > 0){
+    	data.setOffset((pageIndex - 1) * NUMBER_OF_RESULT_PER_PAGE);
+    	data.setLimit(NUMBER_OF_RESULT_PER_PAGE);
+    	uiAdvancePageIterator.setCurrentPage(pageIndex);
+    }
+    else{
+  	  uiAdvancePageIterator.setCurrentPage(0);
+    }
   }
   
   public String getKeyword() {


### PR DESCRIPTION
...ng

Fix description
- Problem:
  *\* Side effect of KS-4407 in new function goToSearchPage in UIWikiAdvanceSearchForm.java
- How to fix ?
  *\* Check condition when searching with no result.
