### PR TITLE
KS-4753 [Forum] Add appropriate exceptions when saving topic and post

### DIFF
--- a/eXoApplication/forum/service/src/main/java/org/exoplatform/forum/service/impl/ForumServiceImpl.java
+++ b/eXoApplication/forum/service/src/main/java/org/exoplatform/forum/service/impl/ForumServiceImpl.java
@@ -290,7 +290,11 @@ public class ForumServiceImpl implements ForumService, Startable {
   public void saveCategory(Category category, boolean isNew) throws Exception {
     storage.saveCategory(category, isNew);
     for (ForumEventLifeCycle f : listeners_) {
-      f.saveCategory(category);
+		try {
+			f.saveCategory(category);
+		} catch (NullPointerException e) {
+			log.error("Error when getting listener " + f.getClass().getName() + " :", e);
+		}
     }
   }
 
@@ -349,7 +353,11 @@ public class ForumServiceImpl implements ForumService, Startable {
   public void saveForum(String categoryId, Forum forum, boolean isNew) throws Exception {
     storage.saveForum(categoryId, forum, isNew);
     for (ForumEventLifeCycle f : listeners_) {
-      f.saveForum(forum);
+		try {
+			f.saveForum(forum);
+		} catch (NullPointerException e) {
+			log.error("Error when getting listener " + f.getClass().getName() + " :", e);
+		}      
     }
   }
 
@@ -414,11 +422,15 @@ public class ForumServiceImpl implements ForumService, Startable {
   public void saveTopic(String categoryId, String forumId, Topic topic, boolean isNew, boolean isMove, MessageBuilder messageBuilder) throws Exception {
     storage.saveTopic(categoryId, forumId, topic, isNew, isMove, messageBuilder);
     for (ForumEventLifeCycle f : listeners_) {
-      if (isNew)
-        f.addTopic(topic, categoryId, forumId);
-      else
-        f.updateTopic(topic, categoryId, forumId);
-    }
+		try {
+			if (isNew)
+				f.addTopic(topic, categoryId, forumId);
+			else
+				f.updateTopic(topic, categoryId, forumId);
+			} catch (NullPointerException e) {
+				log.error("Error when getting listener " + f.getClass().getName() + " :", e);
+			}				
+		}
   }
 
   /**
@@ -551,10 +563,14 @@ public class ForumServiceImpl implements ForumService, Startable {
   public void savePost(String categoryId, String forumId, String topicId, Post post, boolean isNew, MessageBuilder messageBuilder) throws Exception {
     storage.savePost(categoryId, forumId, topicId, post, isNew, messageBuilder);
     for (ForumEventLifeCycle f : listeners_) {
-      if (isNew)
-        f.addPost(post, categoryId, forumId, topicId);
-      else
-        f.updatePost(post, categoryId, forumId, topicId);
+		try {
+			if (isNew)
+				f.addPost(post, categoryId, forumId, topicId);
+			else
+				f.updatePost(post, categoryId, forumId, topicId);
+			} catch (NullPointerException e) {
+			log.error("Error when getting listener " + f.getClass().getName() + " :", e);
+			}
     }
   }
 

--- a/eXoApplication/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UIPostForm.java
+++ b/eXoApplication/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UIPostForm.java
@@ -425,6 +425,7 @@ public class UIPostForm extends BaseForumForm implements UIPopupComponent {
                     isNew = true;
                   } catch (PathNotFoundException e) {
                     isParentDelete = true;
+                  } catch (NullPointerException ne) {
                   }
                   topicDetail.setIdPostView("lastpost");
                 } else {
@@ -438,6 +439,7 @@ public class UIPostForm extends BaseForumForm implements UIPopupComponent {
                     uiForm.getForumService().savePost(uiForm.categoryId, uiForm.forumId, uiForm.topicId, post, false, messageBuilder);
                   } catch (PathNotFoundException e) {
                     isParentDelete = true;
+                  } catch (NullPointerException ne) {
                   }
                   topicDetail.setIdPostView(uiForm.postId);
                 }
@@ -448,6 +450,7 @@ public class UIPostForm extends BaseForumForm implements UIPopupComponent {
                   isNew = true;
                 } catch (PathNotFoundException e) {
                   isParentDelete = true;
+                } catch (NullPointerException ne) {
                 } catch (Exception ex) {
                   uiForm.log.warn(String.format("Failed to save post %s", post.getName()), ex);
                 }

--- a/eXoApplication/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UIQuickReplyForm.java
+++ b/eXoApplication/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UIQuickReplyForm.java
@@ -146,6 +146,7 @@ public class UIQuickReplyForm extends UIForm {
           }
         } catch (PathNotFoundException e) {
           throw new MessageException(new ApplicationMessage("UIPostForm.msg.isParentDelete", null, ApplicationMessage.WARNING));
+		} catch (NullPointerException ne) {          
         }
         textAreaInput.setValue(ForumUtils.EMPTY_STR);
         if (isOffend || hasTopicMod) {

--- a/eXoApplication/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UITopicForm.java
+++ b/eXoApplication/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UITopicForm.java
@@ -23,6 +23,7 @@ import java.util.List;
 import javax.jcr.PathNotFoundException;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
 import org.exoplatform.forum.ForumUtils;
 import org.exoplatform.forum.service.BufferAttachment;
 import org.exoplatform.forum.service.Forum;
@@ -495,6 +496,8 @@ public class UITopicForm extends BaseForumForm implements UISelector {
   }
 
   static public class SubmitThreadActionListener extends BaseEventListener<UITopicForm> {
+	private Log log;
+	
     public void onEvent(Event<UITopicForm> event, UITopicForm uiForm, final String objectId) throws Exception {
       if (uiForm.isDoubleClickSubmit)
         return;
@@ -650,6 +653,7 @@ public class UITopicForm extends BaseForumForm implements UISelector {
                 uiForm.isDoubleClickSubmit = false;
                 warning("UITopicForm.msg.forum-deleted", false);
                 return;
+              } catch (NullPointerException ne) {
               }
             } else {
               topicNew.setVoteRating(0.0);
@@ -678,6 +682,7 @@ public class UITopicForm extends BaseForumForm implements UISelector {
                 warning("UITopicForm.msg.forum-deleted");
                 uiForm.isDoubleClickSubmit = false;
                 return;
+			  } catch (NullPointerException ne) {                
               }
             }
             uiForm.topic = new Topic();
@@ -717,6 +722,7 @@ public class UITopicForm extends BaseForumForm implements UISelector {
           return;
         }
       } catch (Exception e) {
+		log.error(e);
         forumPortlet.updateIsRendered(ForumUtils.CATEGORIES);
         UICategoryContainer categoryContainer = forumPortlet.getChild(UICategoryContainer.class);
         categoryContainer.updateIsRender(true);


### PR DESCRIPTION
- The call of listeners surrounded by try catch in all the methods that call them. By consequent, an appropriate message is added to notify the administrator.
- Another catch added to the call of save in UITopicForm, UIPostForm, UIQuickReplyForm to catch the NullPointerException.
- log.error added when saving topic to inform the administrator about the cause of the exception.
