### PR TITLE
KS-4755: [Wiki] Open link in a new window doesn't work

### DIFF
--- a/eXoApplication/wiki/webapp/src/main/webapp/javascript/eXo/wiki/layout/WikiLayout.js
+++ b/eXoApplication/wiki/webapp/src/main/webapp/javascript/eXo/wiki/layout/WikiLayout.js
@@ -234,4 +234,18 @@ WikiLayout.prototype.heightDelta = function() {
   return this.portal.offsetHeight - document.documentElement.clientHeight;
 };
 
+/*
+ * KS-4755: because target="_blank" is not rendered by rendering service (it's deprecated in xhtml 1.0
+ * and removed in xhtml 1.1), we fix by assign onclick event to open the link in new tab/window 
+ * using javascript for the anchors with attribute rel=__blank
+ */
+WikiLayout.prototype.fixRelBlank = function() {
+  var anchors = document.body.select("a[rel]");
+  for(var i = 0; i < anchors.length; i++) {
+    if(anchors[i].getAttribute("rel") == "__blank") {
+      anchors[i].onclick = function(){window.open(this.getAttribute("href")); return false;};
+    }
+  }
+};
+
 eXo.wiki.WikiLayout = new WikiLayout();

--- a/eXoApplication/wiki/webapp/src/main/webapp/templates/wiki/webui/UIWikiPageContentArea.gtmpl
+++ b/eXoApplication/wiki/webapp/src/main/webapp/templates/wiki/webui/UIWikiPageContentArea.gtmpl
@@ -8,3 +8,8 @@
 <div class="UIWikiPageContentArea" id="$uicomponent.id">
 	<% uicomponent.renderChildren(); %>
 </div>
+
+<%
+// fix anchor with rel="__blank" to open link in new window
+rcontext.getJavascriptManager().addJavascript("eXo.wiki.WikiLayout.fixRelBlank();");
+%>


### PR DESCRIPTION
Fix description:
- Problem: Missing attribute target= "__blank" when rendering from xwiki syntax to xhtml 1.0. The  "target" attribute is deprecated in xhtml 1.0 strict
- How to fix ? Create new function in js file to open on new window in case rel= "__blank"
