### PR TITLE
KS-4696: Cannot save document in Content Explorer in debug mode

### DIFF
--- a/eXoApplication/wiki/webapp/src/main/webapp/javascript/eXo/wiki/UIForm.js
+++ b/eXoApplication/wiki/webapp/src/main/webapp/javascript/eXo/wiki/UIForm.js
@@ -19,9 +19,6 @@
 
 if(!eXo.wiki) eXo.wiki = {};
 
-function UIForm() {
-};
-
 /*ie bug  you cannot have more than one button tag*/
 /**
  * Submits a form with the given action and the given parameters


### PR DESCRIPTION
Problem analysis:
    - UIForm constructor is overridden with empty one in wiki project. As the result, in debug mode, server cannot use function of UIForm from GateIn

Fix description:
    - Remove empty constructor in wiki side to use default constructor from GateIn
