### PR TITLE
KS-4768: Remove domain name of wrong url in old page.

### DIFF
--- a/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
+++ b/eXoApplication/wiki/service/src/main/java/org/exoplatform/wiki/service/impl/WikiServiceImpl.java
@@ -3,6 +3,8 @@ package org.exoplatform.wiki.service.impl;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -503,9 +505,22 @@ public class WikiServiceImpl implements WikiService, Startable {
     }
     
     if (page != null && page.hasPermission(PermissionType.VIEWPAGE)) {
+    	//Check to remove domain name in wiki page url
+    	removeDomainNameInURL(page);
       return page;
     }
     return null;
+  }
+  private void removeDomainNameInURL(PageImpl page){
+	  String url = page.getURL();
+	  if(url != null){
+		  try{
+			  URL oldUrl = new URL(url);
+			  page.setURL(oldUrl.getPath());
+		  }catch(MalformedURLException ex){
+		  	
+		  }
+	  }
   }
 
   public Page getRelatedPage(String wikiType, String wikiOwner, String pageId) throws Exception {


### PR DESCRIPTION
Fix description: Check old page if has domain name in url then remove it from url page.
